### PR TITLE
Feat: 기본 Spring Security 설정 구현

### DIFF
--- a/src/main/java/com/guessthesong/machutogether/security/SecurityConfig.java
+++ b/src/main/java/com/guessthesong/machutogether/security/SecurityConfig.java
@@ -1,0 +1,22 @@
+package com.guessthesong.machutogether.security;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(auth -> auth
+            .requestMatchers("/").authenticated()
+            .anyRequest().permitAll()
+        );
+        http.formLogin(withDefaults());
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 변경 사항 설명
기본 Spring Security 설정을 구현했습니다.

## 주요 변경 내용
- SecurityConfig 클래스 생성 및 기본 보안 설정 구현
- 루트 경로('/')에 대해서만 인증 요구
- 다른 모든 경로는 인증 없이 접근 허용
- 기본 폼 로그인 기능 활성화

## 테스트 방법
1. 애플리케이션 실행
2. 루트 경로('/') 접근 시 로그인 요구 확인

## 주의 사항
- 현재는 기본 설정만 구현되어 있어, 향후 보안 규칙 세분화 필요

## 관련 이슈
Closes #[이슈 번호]