### PR TITLE
Feat: 사용자 등록 서비스 기능 구현 및 비밀번호 암호화 설정 추가

### DIFF
--- a/src/main/java/com/guessthesong/machutogether/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/guessthesong/machutogether/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.guessthesong.machutogether.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException{
+
+    public EmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/guessthesong/machutogether/exception/NicknameAlreadyExistsException.java
+++ b/src/main/java/com/guessthesong/machutogether/exception/NicknameAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.guessthesong.machutogether.exception;
+
+public class NicknameAlreadyExistsException extends RuntimeException {
+
+    public NicknameAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/guessthesong/machutogether/exception/PhoneNumberAlreadyExistsException.java
+++ b/src/main/java/com/guessthesong/machutogether/exception/PhoneNumberAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.guessthesong.machutogether.exception;
+
+public class PhoneNumberAlreadyExistsException extends RuntimeException{
+
+    public PhoneNumberAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/guessthesong/machutogether/exception/UsernameAlreadyExistsException.java
+++ b/src/main/java/com/guessthesong/machutogether/exception/UsernameAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.guessthesong.machutogether.exception;
+
+public class UsernameAlreadyExistsException extends RuntimeException{
+
+    public UsernameAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/guessthesong/machutogether/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/guessthesong/machutogether/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.guessthesong.machutogether.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/guessthesong/machutogether/service/user/UserRegistrationService.java
+++ b/src/main/java/com/guessthesong/machutogether/service/user/UserRegistrationService.java
@@ -1,0 +1,8 @@
+package com.guessthesong.machutogether.service.user;
+
+import com.guessthesong.machutogether.domain.user.UserRegistrationDto;
+
+public interface UserRegistrationService {
+
+    UserRegistrationDto registerUser(UserRegistrationDto registrationDto);
+}

--- a/src/main/java/com/guessthesong/machutogether/service/user/UserRegistrationServiceImpl.java
+++ b/src/main/java/com/guessthesong/machutogether/service/user/UserRegistrationServiceImpl.java
@@ -1,0 +1,70 @@
+package com.guessthesong.machutogether.service.user;
+
+import com.guessthesong.machutogether.domain.user.User;
+import com.guessthesong.machutogether.domain.user.UserMapper;
+import com.guessthesong.machutogether.domain.user.UserRegistrationDto;
+import com.guessthesong.machutogether.exception.EmailAlreadyExistsException;
+import com.guessthesong.machutogether.exception.NicknameAlreadyExistsException;
+import com.guessthesong.machutogether.exception.PhoneNumberAlreadyExistsException;
+import com.guessthesong.machutogether.exception.UsernameAlreadyExistsException;
+import com.guessthesong.machutogether.repository.user.UserRepository;
+
+import jakarta.transaction.Transactional;
+
+import java.time.Instant;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class UserRegistrationServiceImpl implements UserRegistrationService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
+
+    public UserRegistrationServiceImpl(UserRepository userRepository,
+        PasswordEncoder passwordEncoder, UserMapper userMapper) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.userMapper = userMapper;
+    }
+
+    @Override
+    public UserRegistrationDto registerUser(UserRegistrationDto registrationDto) {
+        checkDuplicates(registrationDto);
+
+        User user = User.builder()
+            .username(registrationDto.getUsername())
+            .nickname(registrationDto.getNickname())
+            .email(registrationDto.getEmail())
+            .phoneNumber(registrationDto.getPhoneNumber())
+            .password(getEncodePassword(registrationDto))
+            .createdAt(Instant.now())
+            .isAdmin(false)
+            .build();
+
+        User savedUser = userRepository.save(user);
+        return userMapper.toRegisterDto(savedUser);
+    }
+
+    private String getEncodePassword(UserRegistrationDto registrationDto) {
+        return passwordEncoder.encode(registrationDto.getPassword());
+    }
+
+    private void checkDuplicates(UserRegistrationDto dto) {
+        if (userRepository.existsByUsername(dto.getUsername())) {
+            throw new UsernameAlreadyExistsException("이미 사용중인 아이디 입니다: " + dto.getUsername());
+        }
+        if (userRepository.existsByEmail(dto.getEmail())) {
+            throw new EmailAlreadyExistsException("이미 사용중인 이메일 입니다: " + dto.getEmail());
+        }
+        if (userRepository.existsByNickname(dto.getNickname())) {
+            throw new NicknameAlreadyExistsException("이미 사용중인 닉네임 입니다: " + dto.getNickname());
+        }
+        if (userRepository.existsByPhoneNumber(dto.getPhoneNumber())) {
+            throw new PhoneNumberAlreadyExistsException("이미 사용중인 전화번호 입니다: " + dto.getPhoneNumber());
+        }
+    }
+}

--- a/src/test/java/com/guessthesong/machutogether/service/user/UserRegistrationServiceTest.java
+++ b/src/test/java/com/guessthesong/machutogether/service/user/UserRegistrationServiceTest.java
@@ -1,0 +1,105 @@
+package com.guessthesong.machutogether.service.user;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.guessthesong.machutogether.domain.user.User;
+import com.guessthesong.machutogether.domain.user.UserMapper;
+import com.guessthesong.machutogether.domain.user.UserRegistrationDto;
+import com.guessthesong.machutogether.exception.EmailAlreadyExistsException;
+import com.guessthesong.machutogether.exception.NicknameAlreadyExistsException;
+import com.guessthesong.machutogether.exception.PhoneNumberAlreadyExistsException;
+import com.guessthesong.machutogether.exception.UsernameAlreadyExistsException;
+import com.guessthesong.machutogether.repository.user.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserRegistrationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserRegistrationServiceImpl userRegistrationService;
+
+    private UserRegistrationDto userRegistrationDto;
+
+    @BeforeEach
+    void setUp() {
+        userRegistrationDto = new UserRegistrationDto(
+            "testUser",
+            "Test User",
+            "test@test.com",
+            "password123",
+            "010-1111-1111"
+        );
+    }
+
+    @Test
+    void should_RegisterUser_When_InputIsValid() {
+        when(userRepository.existsByUsername(anyString())).thenReturn(false);
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(userRepository.existsByNickname(anyString())).thenReturn(false);
+        when(userRepository.existsByPhoneNumber(anyString())).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+        when(userRepository.save(any(User.class))).thenReturn(User.builder().build());
+        when(userMapper.toRegisterDto(any(User.class))).thenReturn(userRegistrationDto);
+
+        UserRegistrationDto result = userRegistrationService.registerUser(
+            userRegistrationDto);
+
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void should_RegisterUser_when_UsernameAlreadyExists() {
+        when(userRepository.existsByUsername("testUser")).thenReturn(true);
+
+        assertThrows(UsernameAlreadyExistsException.class, () ->
+            userRegistrationService.registerUser(userRegistrationDto)
+        );
+    }
+
+    @Test
+    void registerUser_EmailAlreadyExists() {
+        when(userRepository.existsByEmail("test@test.com")).thenReturn(true);
+
+        assertThrows(EmailAlreadyExistsException.class, () ->
+            userRegistrationService.registerUser(userRegistrationDto)
+        );
+    }
+
+    @Test
+    void registerUser_NicknameAlreadyExists() {
+        when(userRepository.existsByNickname("Test User")).thenReturn(true);
+
+        assertThrows(NicknameAlreadyExistsException.class, () ->
+            userRegistrationService.registerUser(userRegistrationDto)
+        );
+    }
+
+    @Test
+    void registerUser_PhoneNumberAlreadyExists() {
+        when(userRepository.existsByPhoneNumber("010-1111-1111")).thenReturn(true);
+
+        assertThrows(PhoneNumberAlreadyExistsException.class, () ->
+            userRegistrationService.registerUser(userRegistrationDto)
+        );
+    }
+}


### PR DESCRIPTION
# 변경 사항 설명
사용자 등록 기능 구현 및 비밀번호 암호화 설정 추가

## 주요 변경 내용
-UserRegistrationService 인터페이스 및 구현체 추가
- 사용자 등록 시 중복 검사 로직 구현 (이메일, 닉네임, 사용자명, 전화번호)
- 관련 예외 클래스 추가 (EmailAlreadyExistsException, NicknameAlreadyExistsException 등)
- PasswordEncoder 설정 추가 (BCryptPasswordEncoder 사용)

## 테스트 방법
1. UserRegistrationServiceImpl 테스트 실행
2. 중복된 정보로 사용자 등록 시도하여 예외 발생 확인

## 주의 사항
- 데이터베이스에서 저장된 사용자의 비밀번호가 암호화되었는지 확인 테스트 필요

## 관련 이슈
Related To #10 
