### PR TITLE
Feat: UserRegistrationController 구현 및 테스트

### DIFF
--- a/src/main/java/com/guessthesong/machutogether/controller/user/UserRegistrationController.java
+++ b/src/main/java/com/guessthesong/machutogether/controller/user/UserRegistrationController.java
@@ -1,0 +1,29 @@
+package com.guessthesong.machutogether.controller.user;
+
+import com.guessthesong.machutogether.domain.user.UserRegistrationDto;
+import com.guessthesong.machutogether.service.user.UserRegistrationService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserRegistrationController {
+
+
+    private final UserRegistrationService userService;
+
+    public UserRegistrationController(UserRegistrationService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<UserRegistrationDto> registerUser(@Valid @RequestBody UserRegistrationDto registrationDto) {
+        UserRegistrationDto createdUser = userService.registerUser(registrationDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
+    }
+}

--- a/src/test/java/com/guessthesong/machutogether/controller/user/UserRegistrationControllerTest.java
+++ b/src/test/java/com/guessthesong/machutogether/controller/user/UserRegistrationControllerTest.java
@@ -1,0 +1,72 @@
+package com.guessthesong.machutogether.controller.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guessthesong.machutogether.domain.user.UserRegistrationDto;
+import com.guessthesong.machutogether.service.user.UserRegistrationService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(UserRegistrationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserRegistrationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserRegistrationService userRegistrationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private UserRegistrationDto validUserDto;
+
+    @BeforeEach
+    void setUp() {
+        validUserDto = new UserRegistrationDto(
+            "testuser",
+            "TestNick",
+            "test@email.com",
+            "12341234qwer",
+            "010-3333-3333");
+    }
+
+    @Test
+    void whenValidInput_thenReturn201() throws Exception {
+        when(userRegistrationService.registerUser(any(UserRegistrationDto.class))).thenReturn(
+            validUserDto);
+
+        mockMvc.perform(post("/api/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(validUserDto)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.username").value("testuser"))
+            .andExpect(jsonPath("$.email").value("test@email.com"));
+    }
+
+    @Test
+    void whenInvalidInput_thenReturn400() throws Exception {
+        UserRegistrationDto invalidUser = new UserRegistrationDto("", "", "", "", "");
+
+        ResultActions result = mockMvc.perform(post("/api/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidUser)))
+            .andExpect(status().isBadRequest());
+
+    }
+}


### PR DESCRIPTION
- UserRegistrationController 구현
- UserRegistrationControllerTest 작성

# 변경 사항 설명
사용자 등록 기능을 위한 컨트롤러를 구현하고 관련 단위 테스트를 작성했습니다.
또한 Postman을 사용하여 실제 API 동작을 검증했습니다.

## 주요 변경 내용
- UserRegistrationController에 사용자 등록 엔드포인트 (/api/users/register) 구현
- 입력 데이터 유효성 검사 로직 추가
- UserRegistrationControllerTest에 유효한 입력과 잘못된 입력에 대한 테스트 케이스 추가
- UserRegistrationDto를 사용하여 요청 데이터 처리

## 테스트 방법
1. UserRegistrationControllerTest 실행하여 단위 테스트 확인
2. Postman을 사용하여 다음 API 엔드포인트 테스트:
   POST http://localhost:8080/api/users/register
![image](https://github.com/user-attachments/assets/672ec57c-1c3a-4b12-b03a-5c79a09fd55c)


## 주의 사항
- 현재 구현은 기본적인 유효성 검사만 포함하고 있습니다. 추후 보안 강화가 필요할 수 있습니다.

## 관련 이슈
Related To #10 
