### PR TITLE
Refactor: Chat 엔티티 전반적 리팩토링

### DIFF
--- a/src/main/java/com/guessthesong/machutogether/domain/chat/ChatRoom.java
+++ b/src/main/java/com/guessthesong/machutogether/domain/chat/ChatRoom.java
@@ -6,15 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.time.Instant;
+
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -41,4 +41,13 @@ public class ChatRoom {
     @Column(length = 255)
     private String lastMessagePreview;
 
+    @Builder
+    public ChatRoom(String name, Instant createdAt, Instant lastMessageAt, Integer maxParticipants,
+        String lastMessagePreview) {
+        this.name = name;
+        this.createdAt = createdAt;
+        this.lastMessageAt = lastMessageAt;
+        this.maxParticipants = maxParticipants;
+        this.lastMessagePreview = lastMessagePreview;
+    }
 }

--- a/src/main/java/com/guessthesong/machutogether/domain/chat/ChatRoomMembership.java
+++ b/src/main/java/com/guessthesong/machutogether/domain/chat/ChatRoomMembership.java
@@ -1,5 +1,7 @@
 package com.guessthesong.machutogether.domain.chat;
 
+import com.guessthesong.machutogether.domain.user.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,28 +11,28 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
 import java.time.Instant;
+
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@AllArgsConstructor
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@Table(name = "user_chatroom")
-public class UserChatRoom {
-
+@Table(name = "chat_room_membership")
+public class ChatRoomMembership {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id", nullable = false)
@@ -42,10 +44,12 @@ public class UserChatRoom {
     @Column(nullable = false)
     private boolean isAdmin;
 
-    @Column(length = 50)
-    private String nickname;
-
-    @Column(nullable = false)
-    private boolean notificationEnabled;
+    @Builder
+    public ChatRoomMembership(User user, ChatRoom chatRoom, Instant joinedAt, boolean isAdmin) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+        this.joinedAt = joinedAt;
+        this.isAdmin = isAdmin;
+    }
 
 }

--- a/src/main/java/com/guessthesong/machutogether/domain/chat/Message.java
+++ b/src/main/java/com/guessthesong/machutogether/domain/chat/Message.java
@@ -1,5 +1,7 @@
 package com.guessthesong.machutogether.domain.chat;
 
+import com.guessthesong.machutogether.domain.user.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,15 +12,14 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
 import java.time.Instant;
+
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -43,7 +44,15 @@ public class Message {
     @JoinColumn(name = "chat_room_id", nullable = false)
     private ChatRoom chatRoom;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
+    @Builder
+    public Message(String content, Instant sentAt, ChatRoom chatRoom, User user) {
+        this.content = content;
+        this.sentAt = sentAt;
+        this.chatRoom = chatRoom;
+        this.user = user;
+    }
 }


### PR DESCRIPTION
# 변경 사항 설명
명시적이지 않은 클래스 이름 변경 및 롬복어노테이션 수정

## 주요 변경 내용
- AllArgsConstructor 제거
- 생성자 추가 후 빌더 어노테이션 추가
- user 엔티티와 다대일 관계 설정
- 명시적인 클래스 이름인 ChatRoomMembership 으로 변경


## 주의 사항
- Dto 추가해야 함
- Mapper 클래스 생성시 MapStructure 사용 고려

## 관련 이슈
Related To #21 
